### PR TITLE
Link to how to generate identity

### DIFF
--- a/mini-manuals/6-access-token.md
+++ b/mini-manuals/6-access-token.md
@@ -40,7 +40,7 @@ Content-Type: application/json
   ]
 }
 ```
-`identity` and `credentials` are optional. `identity` is required for any resources that requires *userContext* or if a credential includes a `credentialSubject.subject`.
+`identity` and `credentials` are optional. `identity` is required for any resources that requires *userContext* or if a credential includes a `credentialSubject.subject`. See the [authentication mini manual](7-authentication.md) for instruction on how to generate the value for `identity`.
 `credentials` are required when stated by the access policy of a bolt.
 The Nuts node expects that the custodian has a compound service in its DID Document with the correct service type.
 In that compound service, it expects an `oauth` key/value pair. When resolved that value points to an authorization server.


### PR DESCRIPTION
You need to to have a value for `identity` to generate an access token, but the process of generating that value is only described in the _next_ mini manual. This extra pointer would've helped me.