### PR TITLE
Document registration of NutsComm endpoint on vendor and care organization DID documents

### DIFF
--- a/mini-manuals/2-vendor-registration.md
+++ b/mini-manuals/2-vendor-registration.md
@@ -150,3 +150,26 @@ GET http://localhost:1323/internal/vdr/v1/did/{did}
 ```
 
 You can find a code sample for creating a DID and updating the contact info here: https://github.com/nuts-foundation/nuts-registry-admin-demo/blob/HEAD/domain/sp/service.go#L40-L79
+
+## Registering NutsComm endpoint
+
+To exchange private transactions (transactions that contain PII, personally identifiable information) your node's connections need to be authenticated with its DID document.
+This requires your node's `NutsComm` endpoint to be registered on the DID document.
+It is the endpoint that can be used by other nodes to connect to your node, and is required for authenticated connections.
+It must be in the format of `grpc://<host>:<port>`. You can register it through:
+
+```http request
+POST http://localhost:1323/internal/didman/v1/did/{did}/endpoint
+Content-Type: application/json
+
+{
+  "type": "NutsComm",
+  "endpoint": "grpc://nodeA:5555"
+}
+```
+
+You should restart your node to re-establish network connections to make sure they're properly authenticated.
+
+Other Nuts nodes will now discover your node and start connecting to it. You're also set up to send and receive private transactions.
+
+Note: your node's DID is automatically discovered when not in strict mode, but you can explicitly set it through `network.nodedid`.

--- a/mini-manuals/3-customer-registration.md
+++ b/mini-manuals/3-customer-registration.md
@@ -183,6 +183,21 @@ A search will return converted results. Each credential type within a concept is
 
 Code sample: https://github.com/nuts-foundation/nuts-registry-admin-demo/blob/HEAD/domain/credentials/service.go#L99-L129
 
+## Registering NutsComm endpoint
+
+For an organization to receive private transactions, it needs to publish its `NutsComm` endpoint on its DID document.
+It will refer to the vendor's `NutsComm` endpoint, by registering an endpoint reference (given `{client_did}` and `{vendor_did}`):
+
+```http request
+POST http://localhost:1323/internal/didman/v1/did/{client_did}/endpoint
+Content-Type: application/json
+
+{
+  "type": "NutsComm",
+  "endpoint": "{vendor_did}/serviceEndpoint?type=NutsComm"
+}
+```
+
 ## Trust
 
 By default, a search will only yield *trusted* credentials. A credential is trusted when its issuer is trusted.


### PR DESCRIPTION
Required for authenticated connections, but was missing.